### PR TITLE
feat(API): support path for listFolder, support stat call

### DIFF
--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -76,6 +76,31 @@ public interface ApiClient {
     Call<RemoteFolder> listFolder(long folderId, boolean recursively);
 
     /**
+     * Load a specified folder.
+     * <p>
+     * Same as calling {@link #listFolder(long, boolean)} )} with {@code recursive} set to false.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/folder/listfolder.html" target="_blank">documentation page</a>
+     *
+     * @param path {@link RemoteFolder} path
+     * @return {@link Call}
+     */
+    Call<RemoteFolder> listFolder(String path);
+
+    /**
+     * Load a specified folder.
+     * <p>
+     * Loads the metadata about the folder with the provided folder id.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/folder/listfolder.html" target="_blank">documentation page</a>.
+     *
+     * @param path    target folder path
+     * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
+     * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested fodler id.
+     */
+    Call<RemoteFolder> listFolder(String path, boolean recursively);
+
+    /**
      * Create a new folder.
      * <p>Create a new folder in the specified folder</p>
      * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/createfolder.html" target="_blank">documentation page</a>.</p>
@@ -803,6 +828,30 @@ public interface ApiClient {
      * @see #renameFolder(long, String)
      */
     Call<? extends RemoteEntry> rename(String id, String newFilename);
+
+    /**
+     * Load a specific file.
+     * <p>
+     * Loads the metadata about the file with the provided {@code fileId).
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/stat.html" target="_blank">documentation page</a>.
+     *
+     * @param fileId     target file id.
+     * @return {@link Call} resulting in a {@link RemoteFile} instance holding the metadata for the requested file id.
+     */
+    Call<RemoteFile> stat(long fileId);
+
+    /**
+     * Load a specific file.
+     * <p>
+     * Loads the metadata about the file with the provided {@code path).
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/stat.html" target="_blank">documentation page</a>.
+     *
+     * @param path     target file path.
+     * @return {@link Call} resulting in a {@link RemoteFile} instance holding the metadata for the requested path.
+     */
+    Call<RemoteFile> stat(String path);
 
     /**
      * Move a specified file.

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -71,9 +71,23 @@ public interface ApiClient {
      *
      * @param folderId    target folder id
      * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
-     * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested fodler id.
+     * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested folder id.
      */
     Call<RemoteFolder> listFolder(long folderId, boolean recursively);
+
+    /**
+     * Load a specified folder.
+     * <p>
+     * Loads the metadata about the folder with the provided folder id.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/folder/listfolder.html" target="_blank">documentation page</a>.
+     *
+     * @param folderId    target folder id
+     * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
+     * @param noshares    if false, the folder tree will also include shared files and folders, otherwise resulting {@linkplain RemoteFolder folder} will contain only childer owned by the user
+     * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested folder id.
+     */
+    Call<RemoteFolder> listFolder(long folderId, boolean recursively, boolean noshares);
 
     /**
      * Load a specified folder.
@@ -94,11 +108,25 @@ public interface ApiClient {
      * <p>
      * For more information, see the related <a href="https://docs.pcloud.com/methods/folder/listfolder.html" target="_blank">documentation page</a>.
      *
-     * @param path    target folder path
+     * @param path        target folder path
      * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
      * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested fodler id.
      */
     Call<RemoteFolder> listFolder(String path, boolean recursively);
+
+    /**
+     * Load a specified folder.
+     * <p>
+     * Loads the metadata about the folder with the provided folder id.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/folder/listfolder.html" target="_blank">documentation page</a>.
+     *
+     * @param path    target folder path
+     * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
+     * @param noshares    if false, the folder tree will also include shared files and folders, otherwise resulting {@linkplain RemoteFolder folder} will contain only childer owned by the user
+     * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested folder id.
+     */
+    Call<RemoteFolder> listFolder(String path, boolean recursively, boolean noshares);
 
     /**
      * Create a new folder.

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -144,7 +144,17 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> listFolder(long folderId, boolean recursively) {
-        return newCall(createListFolderRequest(folderId, recursively), new ResponseAdapter<RemoteFolder>() {
+        return newCall(createListFolderRequest(folderId, recursively, true), new ResponseAdapter<RemoteFolder>() {
+            @Override
+            public RemoteFolder adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFolderResponse.class).getFolder();
+            }
+        });
+    }
+
+    @Override
+    public Call<RemoteFolder> listFolder(long folderId, boolean recursively, boolean noshares) {
+        return newCall(createListFolderRequest(folderId, recursively, noshares), new ResponseAdapter<RemoteFolder>() {
             @Override
             public RemoteFolder adapt(Response response) throws IOException, ApiError {
                 return getAsApiResponse(response, GetFolderResponse.class).getFolder();
@@ -159,7 +169,17 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> listFolder(String path, boolean recursively) {
-        return newCall(createListFolderRequest(path, recursively), new ResponseAdapter<RemoteFolder>() {
+        return newCall(createListFolderRequest(path, recursively, true), new ResponseAdapter<RemoteFolder>() {
+            @Override
+            public RemoteFolder adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFolderResponse.class).getFolder();
+            }
+        });
+    }
+
+    @Override
+    public Call<RemoteFolder> listFolder(String path, boolean recursively, boolean noshares) {
+        return newCall(createListFolderRequest(path, recursively, noshares), new ResponseAdapter<RemoteFolder>() {
             @Override
             public RemoteFolder adapt(Response response) throws IOException, ApiError {
                 return getAsApiResponse(response, GetFolderResponse.class).getFolder();
@@ -967,11 +987,15 @@ class RealApiClient implements ApiClient {
         return new Request.Builder().url(apiHost);
     }
 
-    private Request createListFolderRequest(long folderId, boolean recursive) {
+    private Request createListFolderRequest(long folderId, boolean recursive, boolean noshares) {
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
-                .addQueryParameter("folderid", String.valueOf(folderId))
-                .addQueryParameter("noshares", String.valueOf(1));
+                .addQueryParameter("folderid", String.valueOf(folderId));
+
+        if (noshares) {
+            urlBuilder.addEncodedQueryParameter("noshares", String.valueOf(1));
+        }
+
         if (recursive) {
             urlBuilder.addEncodedQueryParameter("recursive", String.valueOf(1));
         }
@@ -982,11 +1006,11 @@ class RealApiClient implements ApiClient {
                 .build();
     }
 
-    private Request createListFolderRequest(String path, boolean recursive) {
+    private Request createListFolderRequest(String path, boolean recursive, boolean noshares) {
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
                 .addEncodedQueryParameter("path", String.valueOf(path))
-                .addQueryParameter("noshares", String.valueOf(1));
+                .addQueryParameter("noshares", noshares ? String.valueOf(1) : String.valueOf(0));
         if (recursive) {
             urlBuilder.addEncodedQueryParameter("recursive", String.valueOf(1));
         }

--- a/java-core/src/test/java/com/pcloud/sdk/ApiClientIntegrationTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiClientIntegrationTest.java
@@ -59,6 +59,18 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testListFolderPath() throws Exception {
+        apiClient.listFolder("/").execute();
+    }
+
+    @Test
+    public void testGetFolderPath() throws Exception {
+        long id = RemoteFolder.ROOT_FOLDER_ID;
+        RemoteFolder folder = apiClient.listFolder("/", true).execute();
+        assertEquals(id, folder.folderId());
+    }
+
+    @Test
     public void testCreateFolder() throws IOException, ApiError {
         RemoteFolder remoteFolder = createRemoteFolder();
 
@@ -194,6 +206,24 @@ public class ApiClientIntegrationTest {
         assertNotEquals(remoteFile.name(), renamedFile.name());
     }
 
+    @Test
+    public void testStatFileWithId() throws IOException, ApiError {
+        RemoteFile remoteFile = createRemoteFile();
+        String randomNewName = UUID.randomUUID().toString();
+
+        RemoteFile fetchedFile = apiClient.stat(remoteFile.fileId()).execute();
+
+        assertEquals(remoteFile.fileId(), fetchedFile.fileId());
+    }
+
+    @Test
+    public void testStatFileWithPath() throws IOException, ApiError {
+        RemoteFile remoteFile = createRemoteFile();
+
+        RemoteFile fetchedFile = apiClient.stat("/" + remoteFile.name()).execute();
+
+        assertEquals(remoteFile.fileId(), fetchedFile.fileId());
+    }
 
     @Test
     public void testDownloadFileFromLink() throws IOException, ApiError {

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -75,6 +75,16 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFolder> listFolder(String path) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFolder> listFolder(String path, boolean recursively) {
+        return null;
+    }
+
+    @Override
     public Call<RemoteFolder> createFolder(long parentFolderId, String folderName) {
         return null;
     }
@@ -291,6 +301,16 @@ public class DummyDownloadingApiClient implements ApiClient {
 
     @Override
     public Call<? extends RemoteEntry> rename(String id, String newFilename) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> stat(long fileid) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> stat(String path) {
         return null;
     }
 

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -75,12 +75,22 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFolder> listFolder(long folderId, boolean recursively, boolean noshares) {
+        return null;
+    }
+
+    @Override
     public Call<RemoteFolder> listFolder(String path) {
         return null;
     }
 
     @Override
     public Call<RemoteFolder> listFolder(String path, boolean recursively) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFolder> listFolder(String path, boolean recursively, boolean noshares) {
         return null;
     }
 


### PR DESCRIPTION
- Add support for `path` variant for `listFolder` (although not recommended)
- Add support for `stat` API call using either `fileId` or `path` (although not recommended)