### PR TITLE
feat(project): introduce path for moveFile and moveFolder

### DIFF
--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -211,6 +211,16 @@ public interface ApiClient {
 
     /**
      * Change a specified folder's parent.
+     * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/renamefolder.html" target="_blank">documentation page</a>.</p>
+     *
+     * @param path   The path of the folder you would like to move
+     * @param toPath The path of the new parent folder
+     * @return {@link Call} resulting in the moved folder's metadata.
+     */
+    Call<RemoteFolder> moveFolder(String path, String toPath);
+
+    /**
+     * Change a specified folder's parent.
      *
      * @param folder   The {@link RemoteFolder} you would like to move. Must not be null.
      * @param toFolder The new parent {@link RemoteFolder}. Must not be null.
@@ -220,6 +230,41 @@ public interface ApiClient {
      * @see #moveFolder(long, long) #moveFolder(long, long)
      */
     Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder);
+
+    /**
+     * Change a specified folder's parent.
+     * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/renamefolder.html" target="_blank">documentation page</a>.</p>
+     *
+     * @param folderId   The id of the folder you would like to move
+     * @param toFolderId The id of the new parent folder
+     * @param toName     The new name of the moved folder
+     * @return {@link Call} resulting in the moved folder's metadata.
+     */
+    Call<RemoteFolder> moveFolder(long folderId, long toFolderId, String toName);
+
+    /**
+     * Change a specified folder's parent.
+     * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/renamefolder.html" target="_blank">documentation page</a>.</p>
+     *
+     * @param path   The path of the folder you would like to move
+     * @param toPath The path of the new parent folder
+     * @param toName The new name of the moved folder
+     * @return {@link Call} resulting in the moved folder's metadata.
+     */
+    Call<RemoteFolder> moveFolder(String path, String toPath, String toName);
+
+    /**
+     * Change a specified folder's parent.
+     *
+     * @param folder   The {@link RemoteFolder} you would like to move. Must not be null.
+     * @param toFolder The new parent {@link RemoteFolder}. Must not be null.
+     * @param toName   The new name of the moved folder
+     * @return {@link Call} resulting in the moved folder's metadata.
+     * @throws IllegalArgumentException on a null {@code folder} argument.
+     * @throws IllegalArgumentException on a null {@code toFolder} argument.
+     * @see #moveFolder(long, long) #moveFolder(long, long)
+     */
+    Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder, String toName);
 
     /**
      * Copy specified folder.
@@ -905,6 +950,64 @@ public interface ApiClient {
      * @see #moveFile(long, long) (long, long)
      */
     Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder);
+
+    /**
+     * Move a specified file.
+     * <p>
+     * The call will move the file specified by the {@code path} argument to the folder specified by the {@code toPath}.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/renamefile.html" target="_blank">documentation page</a>.
+     *
+     * @param path     The path of the file to be moved.
+     * @param toPath   The path of the folder where the file will be moved.
+     * @return {@link Call} resulting in the metadata of the moved file
+     */
+    Call<RemoteFile> moveFile(String path, String toPath);
+
+    /**
+     * Move a specified file.
+     * <p>
+     * The call will move the file specified by the {@code fileId} argument to the folder specified by the {@code toFolderId}.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/renamefile.html" target="_blank">documentation page</a>.
+     *
+     * @param fileId     The file id of the file to be moved.
+     * @param toFolderId The folder id of the folder where the file will be moved.
+     * @param toName     The new name of the moved file
+     * @return {@link Call} resulting in the metadata of the moved file
+     */
+    Call<RemoteFile> moveFile(long fileId, long toFolderId, String toName);
+
+    /**
+     * Move a specified file.
+     * <p>
+     * Same as calling {@link #moveFile(long, long)} (long, long)}
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/renamefile.html" target="_blank">documentation page</a>.
+     *
+     * @param file     The {@link RemoteFile} to be moved. Must not be null.
+     * @param toFolder The {@link RemoteFolder} where the file will be moved. Must not be null.
+     * @param toName   The new name of the moved file
+     * @return {@link Call} resulting in the metadata of the moved file
+     * @throws IllegalArgumentException on a null {@code file} argument.
+     * @throws IllegalArgumentException on a null {@code toFolder} argument.
+     * @see #moveFile(long, long) (long, long)
+     */
+    Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder, String toName);
+
+    /**
+     * Move a specified file.
+     * <p>
+     * The call will move the file specified by the {@code path} argument to the folder specified by the {@code toPath}.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/renamefile.html" target="_blank">documentation page</a>.
+     *
+     * @param path     The path of the file to be moved.
+     * @param toPath   The path of the folder where the file will be moved.
+     * @param toName   The new name of the moved file
+     * @return {@link Call} resulting in the metadata of the moved file
+     */
+    Call<RemoteFile> moveFile(String path, String toPath, String toName);
 
     /**
      * Rename a specified file.

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -712,10 +712,30 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> moveFile(long fileId, long toFolderId) {
-        RequestBody body = new FormBody.Builder()
+        return moveFile(fileId, toFolderId, null);
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder) {
+        return moveFile(file, toFolder, null);
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(String path, String toPath) {
+        return moveFile(path, toPath, null);
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(long fileId, long toFolderId, String toName) {
+        FormBody.Builder builder = new FormBody.Builder()
                 .add("fileid", String.valueOf(fileId))
-                .add("tofolderid", String.valueOf(toFolderId))
-                .build();
+                .add("tofolderid", String.valueOf(toFolderId));
+
+        if(toName != null) {
+            builder.add("toname", toName);
+        }
+
+        RequestBody body = builder.build();
 
         Request request = newRequest()
                 .url(apiHost.newBuilder()
@@ -733,7 +753,7 @@ class RealApiClient implements ApiClient {
     }
 
     @Override
-    public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder) {
+    public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder, String toName) {
         if (file == null) {
             throw new IllegalArgumentException("file argument cannot be null.");
         }
@@ -741,7 +761,34 @@ class RealApiClient implements ApiClient {
             throw new IllegalArgumentException("toFolder argument cannot be null.");
         }
 
-        return moveFile(file.fileId(), toFolder.folderId());
+        return moveFile(file.fileId(), toFolder.folderId(), toName);
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(String path, String toPath, String toName) {
+        FormBody.Builder builder = new FormBody.Builder()
+                .addEncoded("path", path)
+                .addEncoded("topath", toPath);
+
+        if(toName != null) {
+            builder.add("toname", toName);
+        }
+
+        RequestBody body = builder.build();
+
+        Request request = newRequest()
+                .url(apiHost.newBuilder()
+                        .addPathSegment("renamefile")
+                        .build())
+                .post(body)
+                .build();
+
+        return newCall(request, new ResponseAdapter<RemoteFile>() {
+            @Override
+            public RemoteFile adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFileResponse.class).getFile();
+            }
+        });
     }
 
     @Override
@@ -890,19 +937,66 @@ class RealApiClient implements ApiClient {
     }
 
     @Override
-    public Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder) {
-        if (folder == null || toFolder == null) {
-            throw new IllegalArgumentException("folder argument cannot be null.");
-        }
-        return moveFolder(folder.folderId(), toFolder.folderId());
+    public Call<RemoteFolder> moveFolder(long folderId, long toFolderId) {
+        return moveFolder(folderId, toFolderId, null);
     }
 
     @Override
-    public Call<RemoteFolder> moveFolder(long folderId, long toFolderId) {
-        RequestBody body = new FormBody.Builder()
+    public Call<RemoteFolder> moveFolder(String path, String toPath) {
+        return moveFolder(path, toPath, null);
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder) {
+        return moveFolder(folder, toFolder, null);
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder, String toName) {
+        if (folder == null || toFolder == null) {
+            throw new IllegalArgumentException("folder argument cannot be null.");
+        }
+        return moveFolder(folder.folderId(), toFolder.folderId(), toName);
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(long folderId, long toFolderId, String toName) {
+        FormBody.Builder builder = new FormBody.Builder()
                 .add("folderid", String.valueOf(folderId))
-                .add("tofolderid", String.valueOf(toFolderId))
+                .add("tofolderid", String.valueOf(toFolderId));
+
+        if(toName != null) {
+            builder.add("toname", toName);
+        }
+
+        RequestBody body = builder.build() ;
+
+        Request request = newRequest()
+                .url(apiHost.newBuilder()
+                        .addPathSegment("renamefolder")
+                        .build())
+                .post(body)
                 .build();
+
+        return newCall(request, new ResponseAdapter<RemoteFolder>() {
+            @Override
+            public RemoteFolder adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFolderResponse.class).getFolder();
+            }
+        });
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(String path, String toPath, String toName) {
+        FormBody.Builder builder = new FormBody.Builder()
+                .addEncoded("path", path)
+                .addEncoded("topath", toPath);
+
+        if(toName != null) {
+            builder.add("toname", toName);
+        }
+
+        RequestBody body = builder.build() ;
 
         Request request = newRequest()
                 .url(apiHost.newBuilder()

--- a/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
@@ -141,7 +141,7 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void moveFolder_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.moveFolder(null, null);
+        instance.moveFolder((RemoteFolder) null, (RemoteFolder) null);
     }
 
     @Test

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -135,6 +135,26 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFolder> moveFolder(String path, String toPath) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(long folderId, long toFolderId, String toName) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder, String toName) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(String path, String toPath, String toName) {
+        return null;
+    }
+
+    @Override
     public Call<RemoteFolder> copyFolder(long folderId, long toFolderId) {
         return null;
     }
@@ -331,6 +351,26 @@ public class DummyDownloadingApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(String path, String toPath) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(long fileId, long toFolderId, String toName) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder, String toName) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(String path, String toPath, String toName) {
         return null;
     }
 


### PR DESCRIPTION
This change introduces the following:
- `moveFile()`: allow to move files using paths instead of IDs
- `moveFolder()`: allow to move folders using paths instead of IDs
- Introduce `toName` to allow a folder or file to be renamed after being
  moved.