### PR TITLE
feat(project): introduce path for various operations

### DIFF
--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -126,6 +126,19 @@ public interface ApiClient {
     Call<RemoteFolder> createFolder(RemoteFolder parentFolder, String folderName);
 
     /**
+     * Create a folder.
+     * <p>
+     * Same as calling {@link #createFolder(long, String)} with {@code parentFolderId} taken from {@linkplain RemoteFolder#folderId()}.
+     *
+     * @param path       The path of the parent folder for the newly created folder
+     * @param folderName The new folder name
+     * @return {@link Call}
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code folderName} argument.
+     */
+    Call<RemoteFolder> createFolder(String path, String folderName);
+
+    /**
      * Delete a specified folder recursively.
      * <p>
      * Same as calling {@link #deleteFolder(long, boolean)} (long, String)} with {@code recursively} set to false.
@@ -140,7 +153,7 @@ public interface ApiClient {
      * <p>For more information, see the related documentation pages
      * <a href="https://docs.pcloud.com/methods/folder/deletefolder.html" target="_blank">here</a></p> and <a href="https://docs.pcloud.com/methods/folder/deletefolderrecursive.html" target="_blank">here</a>.
      *
-     * @param folderId    The id if the folder you would like to delete
+     * @param folderId    The id of the folder you would like to delete
      * @param recursively If set to {@code true} all child files will also be deleted.
      *                    <p>If set to {@code false}, the operation will fail on any non-empty folder
      * @return {@link Call} resulting in true if the operation is successful, or false otherwise
@@ -168,6 +181,29 @@ public interface ApiClient {
      * @see #deleteFolder(long, boolean) #deleteFolder(long, boolean)
      */
     Call<Boolean> deleteFolder(RemoteFolder folder, boolean recursively);
+
+    /**
+     * Delete a specified folder recursively.
+     * <p>
+     * Same as calling {@link #deleteFolder(String, boolean)} (String, String)} with {@code recursively} set to false.
+     *
+     * @param path The path of the folder you would like to delete
+     * @return {@link Call}
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     */
+    Call<Boolean> deleteFolder(String path);
+
+    /**
+     * Delete a specified folder recursively.
+     * <p>For more information, see the related documentation pages
+     * <a href="https://docs.pcloud.com/methods/folder/deletefolder.html" target="_blank">here</a></p> and <a href="https://docs.pcloud.com/methods/folder/deletefolderrecursive.html" target="_blank">here</a>.
+     *
+     * @param path        The path of the folder you would like to delete
+     * @param recursively If set to {@code true} all child files will also be deleted.
+     *                    <p>If set to {@code false}, the operation will fail on any non-empty folder
+     * @return {@link Call} resulting in true if the operation is successful, or false otherwise
+     */
+    Call<Boolean> deleteFolder(String path, boolean recursively);
 
     /**
      * Rename a specified folder.
@@ -474,6 +510,117 @@ public interface ApiClient {
      */
     Call<RemoteFile> createFile(long folderId, String filename, DataSource data, Date modifiedDate, ProgressListener listener, UploadOptions uploadOptions);
 
+    /**
+     * Create a new file.
+     * <p>
+     * Same as calling {@link #createFile(String, String, DataSource, Date, ProgressListener, UploadOptions)} with null {@code modifiedDate}, {@code listener}
+     * and {@linkplain UploadOptions#DEFAULT} arguments.
+     *
+     * @param path     The path of the folder you would like to create the file.
+     * @param filename The file name. Must not be null.
+     * @param data     {@link DataSource} object providing the file content. Must not be null.
+     * @return {@link Call} resulting in the new file's metadata
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code filename} argument.
+     * @throws IllegalArgumentException on a null {@code data} argument.
+     * @see #createFile(long, String, DataSource, UploadOptions)
+     * @see #createFile(long, String, DataSource, Date, ProgressListener)
+     * @see #createFile(long, String, DataSource, Date, ProgressListener, UploadOptions)
+     * @see DataSource
+     * @see ProgressListener
+     * @see UploadOptions
+     */
+    Call<RemoteFile> createFile(String path, String filename, DataSource data);
+
+
+    /**
+     * Create a new file.
+     * <p>
+     * Same as calling {@link #createFile(String, String, DataSource, Date, ProgressListener, UploadOptions)} with null {@code modifiedDate} and {@code listener} arguments.
+     *
+     * @param path          The path of the folder you would like to create the file.
+     * @param filename      The file name. Must not be null.
+     * @param data          {@link DataSource} object providing the file content. Must not be null.
+     * @param uploadOptions {@link UploadOptions} to be used for the file creation. Must not be null.
+     * @return {@link Call} resulting in the new file's metadata
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code filename} argument.
+     * @throws IllegalArgumentException on a null {@code data} argument.
+     * @throws IllegalArgumentException on a null {@code uploadOptions} argument.
+     * @see #createFile(String, String, DataSource, Date, ProgressListener)
+     * @see #createFile(String, String, DataSource, Date, ProgressListener, UploadOptions)
+     * @see DataSource
+     * @see ProgressListener
+     * @see UploadOptions
+     */
+    Call<RemoteFile> createFile(String path, String filename, DataSource data, UploadOptions uploadOptions);
+
+    /**
+     * Create a new file.
+     * <p>
+     * Creates a new file with the specified name in the specified folder.
+     * <p>
+     * If set, the {@code modifiedDate} parameter will be set as the last modification date of the file.
+     * <p>
+     * The provided {@link DataSource} object will be used to populate the file's contents.
+     * <p>
+     * If a {@link ProgressListener} is provided, it will be notified on every {@code n} bytes uploaded, as set per {@link Builder#progressCallbackThreshold(long)}
+     * <p>
+     * Method is called with a {@link UploadOptions#DEFAULT} argument.
+     * <p>
+     * To create an empty file, call the method with a {@link DataSource#EMPTY} argument.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/uploadfile.html" target="_blank">documentation page</a>.
+     *
+     * @param path         The path of the folder you would like to create the file.
+     * @param filename     The file name. Must not be null.
+     * @param data         {@link DataSource} object providing the file content. Must not be null.
+     * @param modifiedDate The last modification date to be used. If set to {@code null}, the upload date will be used instead.
+     * @param listener     The listener to be used to notify about upload progress. If null, no progress will be reported.
+     * @return {@link Call} resulting in the new file's metadata
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code filename} argument.
+     * @throws IllegalArgumentException on a null {@code data} argument.
+     * @see DataSource
+     * @see ProgressListener
+     * @see UploadOptions
+     */
+    Call<RemoteFile> createFile(String path, String filename, DataSource data, Date modifiedDate, ProgressListener listener);
+
+    /**
+     * Create a new file.
+     * <p>
+     * Creates a new file with the specified name in the specified folder.
+     * <p>
+     * If set, the {@code modifiedDate} parameter will be set as the last modification date of the file.
+     * <p>
+     * The provided {@link DataSource} object will be used to populate the file's contents.
+     * <p>
+     * If a {@link ProgressListener} is provided, it will be notified on every {@code n} bytes uploaded, as set per {@link Builder#progressCallbackThreshold(long)}
+     * <p>
+     * Method uses the supplied {@link UploadOptions}, possible constant for usage are {@link UploadOptions#DEFAULT}, {@link UploadOptions#OVERRIDE_FILE}, {@link UploadOptions#PARTIAL_UPLOAD}.
+     * <p>
+     * To create an empty file, call the method with a {@link DataSource#EMPTY} argument.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/uploadfile.html" target="_blank">documentation page</a>.
+     *
+     * @param path          The path of the folder you would like to create the file.
+     * @param filename      The file name. Must not be null.
+     * @param data          {@link DataSource} object providing the file content. Must not be null.
+     * @param modifiedDate  The last modification date to be used. If set to {@code null}, the upload date will be used instead.
+     * @param listener      The listener to be used to notify about upload progress. If null, no progress will be reported.
+     * @param uploadOptions {@link UploadOptions} to be used for the file creation. Must not be null.
+     * @return {@link Call} resulting in the new file's metadata
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code filename} argument.
+     * @throws IllegalArgumentException on a null {@code data} argument.
+     * @throws IllegalArgumentException on a null {@code uploadOptions} argument.
+     * @see DataSource
+     * @see ProgressListener
+     * @see UploadOptions
+     */
+    Call<RemoteFile> createFile(String path, String filename, DataSource data, Date modifiedDate, ProgressListener listener, UploadOptions uploadOptions);
+
 
     /**
      * Delete a specified file.
@@ -499,6 +646,19 @@ public interface ApiClient {
      * @return {@link Call} resulting in true if operation was successful, false otherwise.
      */
     Call<Boolean> deleteFile(long fileId);
+
+    /**
+     * Delete a specified file.
+     * <p>
+     * Deletes the remote file with the specified path.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/deletefile.html" target="_blank">documentation page</a>.
+     *
+     * @param path of the file to be deleted
+     * @return {@link Call} resulting in true if operation was successful, false otherwise.
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     */
+    Call<Boolean> deleteFile(String path);
 
     /**
      * Create a download link for a file
@@ -536,6 +696,25 @@ public interface ApiClient {
      * @see FileLink
      */
     Call<FileLink> createFileLink(long fileId, DownloadOptions options);
+
+    /**
+     * Create a download link for a file
+     * <p>
+     * If successful, this call will return a {@link FileLink} object, which can be used to download the contents
+     * of the remote file with the specified {@code path}. See {@link DownloadOptions} for more details on possible options
+     * for generating a link.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/streaming/getfilelink.html" target="_blank">documentation page</a>.
+     *
+     * @param path    the file
+     * @param options the options
+     * @return {@link Call} resulting in a {@link FileLink}
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code options} argument.
+     * @see DownloadOptions
+     * @see FileLink
+     */
+    Call<FileLink> createFileLink(String path, DownloadOptions options);
 
     /**
      * Download a {@link FileLink} to a specified destination.

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -204,6 +204,7 @@ public interface ApiClient {
      * @param recursively If set to {@code true} all child files will also be deleted.
      *                    <p>If set to {@code false}, the operation will fail on any non-empty folder
      * @return {@link Call} resulting in true if the operation is successful, or false otherwise
+     * @throws IllegalArgumentException on a null {@code path} argument.
      */
     Call<Boolean> deleteFolder(String path, boolean recursively);
 

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -128,17 +128,15 @@ public interface ApiClient {
     Call<RemoteFolder> createFolder(RemoteFolder parentFolder, String folderName);
 
     /**
-     * Create a folder.
-     * <p>
-     * Same as calling {@link #createFolder(long, String)} with {@code parentFolderId} taken from {@linkplain RemoteFolder#folderId()}.
+     * Create a new folder.
+     * <p>Create a new folder in the specified folder</p>
+     * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/createfolder.html" target="_blank">documentation page</a>.</p>
      *
-     * @param path       The path of the parent folder for the newly created folder
-     * @param folderName The new folder name
-     * @return {@link Call}
+     * @param path       The complete path of the new folder
+     * @return {@link Call} resulting in the metadata for the new folder
      * @throws IllegalArgumentException on a null {@code path} argument.
-     * @throws IllegalArgumentException on a null {@code folderName} argument.
      */
-    Call<RemoteFolder> createFolder(String path, String folderName);
+    Call<RemoteFolder> createFolder(String path);
 
     /**
      * Delete a specified folder recursively.

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -222,6 +222,16 @@ public interface ApiClient {
     Call<RemoteFolder> moveFolder(RemoteFolder folder, RemoteFolder toFolder);
 
     /**
+     * Change a specified folder's parent.
+     * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/renamefolder.html" target="_blank">documentation page</a>.</p>
+     *
+     * @param path   The path of the folder you would like to move
+     * @param toPath The path of the new parent folder
+     * @return {@link Call} resulting in the moved folder's metadata.
+     */
+    Call<RemoteFolder> moveFolder(String path, String toPath);
+
+    /**
      * Copy specified folder.
      * <p>For more information, see the related <a href="https://docs.pcloud.com/methods/folder/renamefolder.html" target="_blank">documentation page</a>.</p>
      *
@@ -905,6 +915,19 @@ public interface ApiClient {
      * @see #moveFile(long, long) (long, long)
      */
     Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder);
+
+    /**
+     * Move a specified file.
+     * <p>
+     * The call will move the file specified by the {@code path} argument to the folder specified by the {@code toPath}.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/renamefile.html" target="_blank">documentation page</a>.
+     *
+     * @param path     The path of the file to be moved.
+     * @param toPath   The path of the folder where the file will be moved.
+     * @return {@link Call} resulting in the metadata of the moved file
+     */
+    Call<RemoteFile> moveFile(String path, String toPath);
 
     /**
      * Rename a specified file.

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -84,6 +84,7 @@ public interface ApiClient {
      *
      * @param path {@link RemoteFolder} path
      * @return {@link Call}
+     * @throws IllegalArgumentException on a null {@code path} argument.
      */
     Call<RemoteFolder> listFolder(String path);
 
@@ -97,6 +98,7 @@ public interface ApiClient {
      * @param path    target folder path
      * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
      * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested fodler id.
+     * @throws IllegalArgumentException on a null {@code path} argument.
      */
     Call<RemoteFolder> listFolder(String path, boolean recursively);
 
@@ -264,6 +266,8 @@ public interface ApiClient {
      * @param path   The path of the folder you would like to move
      * @param toPath The path of the new parent folder
      * @return {@link Call} resulting in the moved folder's metadata.
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code toPath} argument.
      */
     Call<RemoteFolder> moveFolder(String path, String toPath);
 
@@ -1039,6 +1043,7 @@ public interface ApiClient {
      *
      * @param path target file path.
      * @return {@link Call} resulting in a {@link RemoteFile} instance holding the metadata for the requested path.
+     * @throws IllegalArgumentException on a null {@code path} argument.
      */
     Call<RemoteFile> loadFile(String path);
 
@@ -1063,6 +1068,7 @@ public interface ApiClient {
      *
      * @param path target folder path.
      * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested path.
+     * @throws IllegalArgumentException on a null {@code path} argument.
      */
     Call<RemoteFolder> loadFolder(String path);
 
@@ -1105,6 +1111,8 @@ public interface ApiClient {
      * @param path     The path of the file to be moved.
      * @param toPath   The path of the folder where the file will be moved.
      * @return {@link Call} resulting in the metadata of the moved file
+     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null {@code toPath} argument.
      */
     Call<RemoteFile> moveFile(String path, String toPath);
 

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -84,7 +84,7 @@ public interface ApiClient {
      *
      * @param path {@link RemoteFolder} path
      * @return {@link Call}
-     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null or empty {@code path} argument.
      */
     Call<RemoteFolder> listFolder(String path);
 
@@ -98,7 +98,7 @@ public interface ApiClient {
      * @param path    target folder path
      * @param recursively if true, a full folder tree will be returned, otherwise the resulting {@linkplain RemoteFolder folder} will contain only its direct children
      * @return {@link Call} resulting in a {@link RemoteFolder} instance holding the metadata for the requested fodler id.
-     * @throws IllegalArgumentException on a null {@code path} argument.
+     * @throws IllegalArgumentException on a null or empty {@code path} argument.
      */
     Call<RemoteFolder> listFolder(String path, boolean recursively);
 

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -234,6 +234,33 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> createFile(long folderId, String filename, final DataSource data, Date modifiedDate, final ProgressListener listener, final UploadOptions uploadOptions) {
+        return createFile(folderId, null, filename, data, modifiedDate, listener, uploadOptions);
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data) {
+        return createFile(path, filename, data, null, null, UploadOptions.DEFAULT);
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data, UploadOptions uploadOptions) {
+        return createFile(path, filename, data, null, null, uploadOptions);
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data, Date modifiedDate, ProgressListener listener) {
+        return createFile(path, filename, data, modifiedDate, listener, UploadOptions.DEFAULT);
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, final DataSource data, Date modifiedDate, final ProgressListener listener, final UploadOptions uploadOptions) {
+        if (path == null) {
+            throw new IllegalArgumentException("Folder argument cannot be null.");
+        }
+        return createFile(null, path, filename, data, modifiedDate, listener, uploadOptions);
+    }
+
+    private Call<RemoteFile> createFile(Long folderId, String path, String filename, final DataSource data, Date modifiedDate, final ProgressListener listener, final UploadOptions uploadOptions) {
         if (filename == null) {
             throw new IllegalArgumentException("Filename cannot be null.");
         }
@@ -282,9 +309,16 @@ class RealApiClient implements ApiClient {
 
         HttpUrl.Builder urlBuilder = apiHost.newBuilder().
                 addPathSegment("uploadfile")
-                .addQueryParameter("folderid", String.valueOf(folderId))
                 .addQueryParameter("renameifexists", String.valueOf(uploadOptions.overrideFile() ? 0 : 1))
                 .addQueryParameter("nopartial", String.valueOf(uploadOptions.partialUpload() ? 0 : 1));
+
+        if (folderId != null) {
+            urlBuilder.addQueryParameter("folderid", String.valueOf(folderId));
+        }
+
+        if (path != null) {
+            urlBuilder.addEncodedQueryParameter("path", path);
+        }
 
         if (modifiedDate != null) {
             urlBuilder.addQueryParameter("mtime", String.valueOf(TimeUnit.MILLISECONDS.toSeconds(modifiedDate.getTime())));
@@ -337,6 +371,29 @@ class RealApiClient implements ApiClient {
     }
 
     @Override
+    public Call<Boolean> deleteFile(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("path argument cannot be null.");
+        }
+        Request request = new Request.Builder()
+                .url(apiHost.newBuilder()
+                        .addPathSegment("deletefile")
+                        .build())
+                .get()
+                .post(new FormBody.Builder()
+                        .addEncoded("path", path)
+                        .build())
+                .build();
+        return newCall(request, new ResponseAdapter<Boolean>() {
+            @Override
+            public Boolean adapt(Response response) throws IOException, ApiError {
+                GetFileResponse body = deserializeResponseBody(response, GetFileResponse.class);
+                return body.isSuccessful() && body.getFile() != null;
+            }
+        });
+    }
+
+    @Override
     public Call<FileLink> createFileLink(RemoteFile file, DownloadOptions options) {
         if (file == null) {
             throw new IllegalArgumentException("File argument cannot be null.");
@@ -350,7 +407,27 @@ class RealApiClient implements ApiClient {
             throw new IllegalArgumentException("DownloadOptions parameter cannot be null.");
         }
 
-        Request request = newDownloadLinkRequest(fileId, options);
+        Request request = newDownloadLinkRequest(fileId, null, options);
+
+        return newCall(request, new ResponseAdapter<FileLink>() {
+            @Override
+            public FileLink adapt(Response response) throws IOException, ApiError {
+                return getAsFileLink(response);
+            }
+        });
+
+    }
+
+    @Override
+    public Call<FileLink> createFileLink(String path, DownloadOptions options) {
+        if (path == null) {
+            throw new IllegalArgumentException("Path argument cannot be null.");
+        }
+        if (options == null) {
+            throw new IllegalArgumentException("DownloadOptions parameter cannot be null.");
+        }
+
+        Request request = newDownloadLinkRequest(null, path, options);
 
         return newCall(request, new ResponseAdapter<FileLink>() {
             @Override
@@ -371,10 +448,17 @@ class RealApiClient implements ApiClient {
         return new RealFileLink(RealApiClient.this, body.getExpires(), downloadUrls);
     }
 
-    private Request newDownloadLinkRequest(long fileId, DownloadOptions options) {
+    private Request newDownloadLinkRequest(Long fileId, String path, DownloadOptions options) {
         HttpUrl.Builder urlBuilder = apiHost.newBuilder().
-                addPathSegment("getfilelink")
-                .addQueryParameter("fileid", String.valueOf(fileId));
+                addPathSegment("getfilelink");
+
+        if (fileId != null) {
+                urlBuilder.addQueryParameter("fileid", String.valueOf(fileId));
+        }
+
+        if (path != null) {
+            urlBuilder.addEncodedQueryParameter("path", path);
+        }
 
         if (options.forceDownload()) {
             urlBuilder.addQueryParameter("forcedownload", String.valueOf(1));
@@ -456,7 +540,7 @@ class RealApiClient implements ApiClient {
                 .skipFilename(false)
                 .contentType(file.contentType())
                 .build();
-        return newCall(newDownloadLinkRequest(file.fileId(), options), new ResponseAdapter<BufferedSource>() {
+        return newCall(newDownloadLinkRequest(file.fileId(), null, options), new ResponseAdapter<BufferedSource>() {
             @Override
             public BufferedSource adapt(Response response) throws IOException, ApiError {
                 FileLink link = getAsFileLink(response);
@@ -835,6 +919,35 @@ class RealApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFolder> createFolder(String path, String folderName) {
+        if (path == null) {
+            throw new IllegalArgumentException("folder argument cannot be null.");
+        }
+
+        if (folderName == null) {
+            throw new IllegalArgumentException("Folder name is null");
+        }
+
+        RequestBody body = new FormBody.Builder()
+                .addEncoded("path", path)
+                .add("name", folderName)
+                .build();
+
+        Request request = newRequest()
+                .url(apiHost.newBuilder()
+                        .addPathSegment("createfolder").build())
+                .post(body)
+                .build();
+
+        return newCall(request, new ResponseAdapter<RemoteFolder>() {
+            @Override
+            public RemoteFolder adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFolderResponse.class).getFolder();
+            }
+        });
+    }
+
+    @Override
     public Call<Boolean> deleteFolder(RemoteFolder folder) {
         if (folder == null) {
             throw new IllegalArgumentException("folder argument cannot be null.");
@@ -859,6 +972,36 @@ class RealApiClient implements ApiClient {
     public Call<Boolean> deleteFolder(long folderId, boolean recursively) {
         RequestBody body = new FormBody.Builder()
                 .add("folderid", String.valueOf(folderId))
+                .build();
+
+        Request request = newRequest()
+                .url(apiHost.newBuilder()
+                        .addPathSegment(recursively ? "deletefolderrecursive" : "deletefolder")
+                        .build())
+                .post(body)
+                .build();
+
+        return newCall(request, new ResponseAdapter<Boolean>() {
+            @Override
+            public Boolean adapt(Response response) throws IOException, ApiError {
+                getAsApiResponse(response, ApiResponse.class);
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public Call<Boolean> deleteFolder(String path) {
+        return deleteFolder(path, false);
+    }
+
+    @Override
+    public Call<Boolean> deleteFolder(String path, boolean recursively) {
+        if (path == null) {
+            throw new IllegalArgumentException("folder argument cannot be null.");
+        }
+        RequestBody body = new FormBody.Builder()
+                .addEncoded("path", path)
                 .build();
 
         Request request = newRequest()

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -930,18 +930,13 @@ class RealApiClient implements ApiClient {
     }
 
     @Override
-    public Call<RemoteFolder> createFolder(String path, String folderName) {
+    public Call<RemoteFolder> createFolder(String path) {
         if (path == null) {
             throw new IllegalArgumentException("Path argument cannot be null.");
         }
 
-        if (folderName == null) {
-            throw new IllegalArgumentException("Folder name is null");
-        }
-
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
-                .add("name", folderName)
                 .build();
 
         Request request = newRequest()

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -177,7 +177,7 @@ class RealApiClient implements ApiClient {
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
-                .addEncodedQueryParameter("path", String.valueOf(path))
+                .addEncodedQueryParameter("path", path.isEmpty() ? "/" : path)
                 .addQueryParameter("noshares", String.valueOf(1));
         if (recursively) {
             urlBuilder.addEncodedQueryParameter("recursive", String.valueOf(1));

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -733,6 +733,28 @@ class RealApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFile> moveFile(String path, String toPath) {
+        RequestBody body = new FormBody.Builder()
+                .addEncoded("path", path)
+                .addEncoded("topath", toPath)
+                .build();
+
+        Request request = newRequest()
+                .url(apiHost.newBuilder()
+                        .addPathSegment("renamefile")
+                        .build())
+                .post(body)
+                .build();
+
+        return newCall(request, new ResponseAdapter<RemoteFile>() {
+            @Override
+            public RemoteFile adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFileResponse.class).getFile();
+            }
+        });
+    }
+
+    @Override
     public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder) {
         if (file == null) {
             throw new IllegalArgumentException("file argument cannot be null.");
@@ -902,6 +924,28 @@ class RealApiClient implements ApiClient {
         RequestBody body = new FormBody.Builder()
                 .add("folderid", String.valueOf(folderId))
                 .add("tofolderid", String.valueOf(toFolderId))
+                .build();
+
+        Request request = newRequest()
+                .url(apiHost.newBuilder()
+                        .addPathSegment("renamefolder")
+                        .build())
+                .post(body)
+                .build();
+
+        return newCall(request, new ResponseAdapter<RemoteFolder>() {
+            @Override
+            public RemoteFolder adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetFolderResponse.class).getFolder();
+            }
+        });
+    }
+
+    @Override
+    public Call<RemoteFolder> moveFolder(String path, String toPath) {
+        RequestBody body = new FormBody.Builder()
+                .addEncoded("path", path)
+                .addEncoded("topath", toPath)
                 .build();
 
         Request request = newRequest()

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -172,8 +172,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> listFolder(String path, boolean recursively) {
-        if (path == null || path.isEmpty()) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
@@ -256,8 +256,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> createFile(String path, String filename, final DataSource data, Date modifiedDate, final ProgressListener listener, final UploadOptions uploadOptions) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         return createFile(null, path, filename, data, modifiedDate, listener, uploadOptions);
     }
@@ -374,8 +374,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<Boolean> deleteFile(String path) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         Request request = new Request.Builder()
                 .url(apiHost.newBuilder()
@@ -422,8 +422,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<FileLink> createFileLink(String path, DownloadOptions options) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         if (options == null) {
             throw new IllegalArgumentException("DownloadOptions parameter cannot be null.");
@@ -736,8 +736,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> loadFile(String path) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("stat")
@@ -780,8 +780,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> loadFolder(String path) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
@@ -826,8 +826,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> moveFile(String path, String toPath) {
-        if (path == null || toPath == null) {
-            throw new IllegalArgumentException("Path or toPath argument cannot be null.");
+        if (!isValidPath(path) || !isValidPath(toPath)) {
+            throw new IllegalArgumentException("Path or toPath argument cannot be null or empty.");
         }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
@@ -931,8 +931,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> createFolder(String path) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
 
         RequestBody body = new FormBody.Builder()
@@ -1003,8 +1003,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<Boolean> deleteFolder(String path, boolean recursively) {
-        if (path == null) {
-            throw new IllegalArgumentException("Path argument cannot be null.");
+        if (!isValidPath(path)) {
+            throw new IllegalArgumentException("Path argument cannot be null or empty.");
         }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
@@ -1092,8 +1092,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> moveFolder(String path, String toPath) {
-        if (path == null || toPath == null) {
-            throw new IllegalArgumentException("Path or toPath argument cannot be null.");
+        if (!isValidPath(path) || !isValidPath(toPath)) {
+            throw new IllegalArgumentException("Path or toPath argument cannot be null or empty.");
         }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
@@ -1319,5 +1319,9 @@ class RealApiClient implements ApiClient {
                 closeQuietly(response);
             }
         }
+    }
+
+    private boolean isValidPath(String path) {
+        return (path != null && !path.isEmpty());
     }
 }

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -173,7 +173,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<RemoteFolder> listFolder(String path, boolean recursively) {
         if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
@@ -257,7 +257,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<RemoteFile> createFile(String path, String filename, final DataSource data, Date modifiedDate, final ProgressListener listener, final UploadOptions uploadOptions) {
         if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
         return createFile(null, path, filename, data, modifiedDate, listener, uploadOptions);
     }
@@ -375,7 +375,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<Boolean> deleteFile(String path) {
         if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
         Request request = new Request.Builder()
                 .url(apiHost.newBuilder()
@@ -737,7 +737,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<RemoteFile> loadFile(String path) {
         if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("stat")
@@ -781,7 +781,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<RemoteFolder> loadFolder(String path) {
         if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
@@ -826,11 +826,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> moveFile(String path, String toPath) {
-        if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
-        }
-        if (toPath == null) {
-            throw new IllegalArgumentException("toPath argument cannot be null.");
+        if (path == null || toPath == null) {
+            throw new IllegalArgumentException("Path or toPath argument cannot be null.");
         }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
@@ -935,7 +932,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<RemoteFolder> createFolder(String path, String folderName) {
         if (path == null) {
-            throw new IllegalArgumentException("folder argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
 
         if (folderName == null) {
@@ -1012,7 +1009,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<Boolean> deleteFolder(String path, boolean recursively) {
         if (path == null) {
-            throw new IllegalArgumentException("folder argument cannot be null.");
+            throw new IllegalArgumentException("Path argument cannot be null.");
         }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
@@ -1100,11 +1097,8 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> moveFolder(String path, String toPath) {
-        if (path == null) {
-            throw new IllegalArgumentException("path argument cannot be null.");
-        }
-        if (toPath == null) {
-            throw new IllegalArgumentException("toPath argument cannot be null.");
+        if (path == null || toPath == null) {
+            throw new IllegalArgumentException("Path or toPath argument cannot be null.");
         }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -172,12 +172,12 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> listFolder(String path, boolean recursively) {
-        if (path == null) {
+        if (path == null || path.isEmpty()) {
             throw new IllegalArgumentException("Path argument cannot be null.");
         }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
-                .addEncodedQueryParameter("path", path.isEmpty() ? "/" : path)
+                .addEncodedQueryParameter("path", path)
                 .addQueryParameter("noshares", String.valueOf(1));
         if (recursively) {
             urlBuilder.addEncodedQueryParameter("recursive", String.valueOf(1));

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -172,7 +172,9 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> listFolder(String path, boolean recursively) {
-
+        if (path == null) {
+            throw new IllegalArgumentException("path argument cannot be null.");
+        }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
                 .addEncodedQueryParameter("path", String.valueOf(path))
@@ -255,7 +257,7 @@ class RealApiClient implements ApiClient {
     @Override
     public Call<RemoteFile> createFile(String path, String filename, final DataSource data, Date modifiedDate, final ProgressListener listener, final UploadOptions uploadOptions) {
         if (path == null) {
-            throw new IllegalArgumentException("Folder argument cannot be null.");
+            throw new IllegalArgumentException("path argument cannot be null.");
         }
         return createFile(null, path, filename, data, modifiedDate, listener, uploadOptions);
     }
@@ -734,6 +736,9 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> loadFile(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("path argument cannot be null.");
+        }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("stat")
                 .addEncodedQueryParameter("path", String.valueOf(path));
@@ -775,6 +780,9 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> loadFolder(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("path argument cannot be null.");
+        }
         HttpUrl.Builder urlBuilder = apiHost.newBuilder()
                 .addPathSegment("listfolder")
                 .addQueryParameter("path", path)
@@ -818,6 +826,12 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> moveFile(String path, String toPath) {
+        if (path == null) {
+            throw new IllegalArgumentException("path argument cannot be null.");
+        }
+        if (toPath == null) {
+            throw new IllegalArgumentException("toPath argument cannot be null.");
+        }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
                 .addEncoded("topath", toPath)
@@ -1086,6 +1100,12 @@ class RealApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFolder> moveFolder(String path, String toPath) {
+        if (path == null) {
+            throw new IllegalArgumentException("path argument cannot be null.");
+        }
+        if (toPath == null) {
+            throw new IllegalArgumentException("toPath argument cannot be null.");
+        }
         RequestBody body = new FormBody.Builder()
                 .addEncoded("path", path)
                 .addEncoded("topath", toPath)

--- a/java-core/src/test/java/com/pcloud/sdk/ApiClientIntegrationTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiClientIntegrationTest.java
@@ -54,19 +54,12 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
-    public void testGetFolder() throws Exception {
-        long id = RemoteFolder.ROOT_FOLDER_ID;
-        RemoteFolder folder = apiClient.listFolder(id, true).execute();
-        assertEquals(id, folder.folderId());
-    }
-
-    @Test
-    public void testListFolderPath() throws Exception {
+    public void testListFolderByPath() throws Exception {
         apiClient.listFolder("/").execute();
     }
 
     @Test
-    public void testGetFolderPath() throws Exception {
+    public void testGetFolderByPath() throws Exception {
         long id = RemoteFolder.ROOT_FOLDER_ID;
         RemoteFolder folder = apiClient.listFolder("/", true).execute();
         assertEquals(id, folder.folderId());
@@ -80,9 +73,22 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testCreateFolderByPath() throws IOException, ApiError {
+        RemoteFolder remoteFolder = createRemoteFolder("/");
+
+        assertTrue(entryExistsInRoot(remoteFolder));
+    }
+
+    @Test
     public void testDeleteFolder() throws IOException, ApiError {
         RemoteFolder remoteFolder = createRemoteFolder();
         assertTrue(apiClient.deleteFolder(remoteFolder).execute());
+    }
+
+    @Test
+    public void testDeleteFolderByPath() throws IOException, ApiError {
+        RemoteFolder remoteFolder = createRemoteFolder("/");
+        assertTrue(apiClient.deleteFolder("/" + remoteFolder.name()).execute());
     }
 
     @Test
@@ -90,6 +96,13 @@ public class ApiClientIntegrationTest {
         RemoteFolder remoteFolder = createRemoteFolder();
         createRemoteFolder(remoteFolder.folderId());
         assertTrue(apiClient.deleteFolder(remoteFolder, true).execute());
+    }
+
+    @Test
+    public void testDeleteFolderRecursivelyByPath() throws IOException, ApiError {
+        RemoteFolder remoteFolder = createRemoteFolder("/");
+        createRemoteFolder("/" + remoteFolder.name() + "/");
+        assertTrue(apiClient.deleteFolder("/" + remoteFolder.name(), true).execute());
     }
 
     @Test
@@ -115,6 +128,17 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testMoveFolderByPath() throws IOException, ApiError {
+        RemoteFolder remoteFolder1 = createRemoteFolder("/");
+        RemoteFolder remoteFolder2 = createRemoteFolder("/");
+
+        RemoteFolder movedFolder = apiClient.moveFolder("/" + remoteFolder1.name(), "/" + remoteFolder2.name() + "/" + remoteFolder1.name()).execute();
+
+        assertTrue(entryExistsInFolder(movedFolder, remoteFolder2.folderId()));
+        assertFalse(entryExistsInFolder(remoteFolder1, RemoteFolder.ROOT_FOLDER_ID));
+    }
+
+    @Test
     public void testCopyFolder() throws IOException, ApiError {
         RemoteFolder remoteFolder1 = createRemoteFolder();
         RemoteFolder remoteFolder2 = createRemoteFolder();
@@ -124,7 +148,6 @@ public class ApiClientIntegrationTest {
         assertTrue(entryExistsInFolder(copiedFolder, remoteFolder2.folderId()));
         assertTrue(entryExistsInFolder(remoteFolder1, RemoteFolder.ROOT_FOLDER_ID));
     }
-
 
     @Test
     public void testCreateFile() throws IOException, ApiError {
@@ -137,12 +160,35 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testCreateFileByPath() throws IOException, ApiError {
+        String someName = UUID.randomUUID().toString();
+        byte[] fileContents = someName.getBytes();
+        RemoteFile remoteFile = apiClient.createFile("/", someName + ".txt", DataSource.create(fileContents)).execute();
+
+        assertTrue(entryExistsInRoot(remoteFile));
+        assertEquals(fileContents.length, remoteFile.size());
+    }
+
+    @Test
     public void testCreateFileWithDate() throws IOException, ApiError {
         String someName = UUID.randomUUID().toString();
         byte[] fileContents = someName.getBytes();
         Date dateModified = new Date(1484902140000L);//Random date
         ProgressListener listener = Mockito.mock(ProgressListener.class);
         RemoteFile remoteFile = apiClient.createFile(RemoteFolder.ROOT_FOLDER_ID, someName + ".txt", DataSource.create(fileContents), dateModified, listener).execute();
+
+        assertTrue(entryExistsInRoot(remoteFile));
+        assertEquals(fileContents.length, remoteFile.size());
+        assertEquals(dateModified, remoteFile.created());
+    }
+
+    @Test
+    public void testCreateFileWithDateByPath() throws IOException, ApiError {
+        String someName = UUID.randomUUID().toString();
+        byte[] fileContents = someName.getBytes();
+        Date dateModified = new Date(1484902140000L);//Random date
+        ProgressListener listener = Mockito.mock(ProgressListener.class);
+        RemoteFile remoteFile = apiClient.createFile("/", someName + ".txt", DataSource.create(fileContents), dateModified, listener).execute();
 
         assertTrue(entryExistsInRoot(remoteFile));
         assertEquals(fileContents.length, remoteFile.size());
@@ -164,10 +210,34 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testCreateFileWithOverrideOptionByPath() throws IOException, ApiError {
+        String someName = UUID.randomUUID().toString() + ".txt";
+        byte[] fileContents = someName.getBytes();
+        byte[] file2Contents = UUID.randomUUID().toString().getBytes();
+        RemoteFile remoteFile = apiClient.createFile("/", someName, DataSource.create(fileContents), UploadOptions.OVERRIDE_FILE).execute();
+        RemoteFile remoteFile2 = apiClient.createFile("/", someName, DataSource.create(file2Contents), UploadOptions.OVERRIDE_FILE).execute();
+
+        assertFalse(entryExistsInRoot(remoteFile));
+        assertTrue(entryExistsInRoot(remoteFile2));
+        assertEquals(someName, remoteFile2.name());
+        assertEquals(file2Contents.length, remoteFile2.size());
+    }
+
+    @Test
     public void testDeleteFile() throws IOException, ApiError {
         RemoteFile remoteFile = createRemoteFile();
 
         Boolean isDeleted = apiClient.deleteFile(remoteFile).execute();
+
+        assertTrue(isDeleted);
+        assertFalse(entryExistsInRoot(remoteFile));
+    }
+
+    @Test
+    public void testDeleteFileByPath() throws IOException, ApiError {
+        RemoteFile remoteFile = createRemoteFile("/");
+
+        Boolean isDeleted = apiClient.deleteFile("/" + remoteFile.name()).execute();
 
         assertTrue(isDeleted);
         assertFalse(entryExistsInRoot(remoteFile));
@@ -179,6 +249,17 @@ public class ApiClientIntegrationTest {
         RemoteFile remoteFile = createRemoteFile();
 
         RemoteFile movedFile = apiClient.moveFile(remoteFile, remoteFolder).execute();
+
+        assertTrue(entryExistsInFolder(movedFile, remoteFolder.folderId()));
+        assertFalse(entryExistsInFolder(remoteFile, RemoteFolder.ROOT_FOLDER_ID));
+    }
+
+    @Test
+    public void testMoveFileBy() throws IOException, ApiError {
+        RemoteFolder remoteFolder = createRemoteFolder("/");
+        RemoteFile remoteFile = createRemoteFile("/");
+
+        RemoteFile movedFile = apiClient.moveFile("/" + remoteFile.name(), "/" + remoteFolder.name() + "/").execute();
 
         assertTrue(entryExistsInFolder(movedFile, remoteFolder.folderId()));
         assertFalse(entryExistsInFolder(remoteFile, RemoteFolder.ROOT_FOLDER_ID));
@@ -219,7 +300,7 @@ public class ApiClientIntegrationTest {
 
     @Test
     public void testLoadFileWithPath() throws IOException, ApiError {
-        RemoteFile remoteFile = createRemoteFile();
+        RemoteFile remoteFile = createRemoteFile("/");
 
         RemoteFile fetchedFile = apiClient.loadFile("/" + remoteFile.name()).execute();
 
@@ -238,7 +319,7 @@ public class ApiClientIntegrationTest {
 
     @Test
     public void testLoadFolderWithPath() throws IOException, ApiError {
-        RemoteFolder remoteFolder = createRemoteFolder();
+        RemoteFolder remoteFolder = createRemoteFolder("/");
 
         RemoteFolder fetchedFolder = apiClient.loadFolder("/" + remoteFolder.name()).execute();
 
@@ -263,6 +344,22 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testDownloadFileFromLinkByPath() throws IOException, ApiError {
+        String someName = UUID.randomUUID().toString();
+        byte[] fileContents = someName.getBytes();
+        RemoteFile remoteFile = apiClient.createFile("/", someName + ".txt", DataSource.create(fileContents)).execute();
+        DownloadOptions options = DownloadOptions.create()
+                .skipFilename(true)
+                .forceDownload(false)
+                .contentType(remoteFile.contentType())
+                .build();
+
+        FileLink fileLink = apiClient.createFileLink("/" + remoteFile.name(), options).execute();
+        BufferedSource source = apiClient.download(fileLink).execute();
+        assertArrayEquals(fileContents, source.readByteArray());
+    }
+
+    @Test
     public void testDownloadFile() throws IOException, ApiError {
         String someName = UUID.randomUUID().toString();
         byte[] fileContents = someName.getBytes();
@@ -281,10 +378,21 @@ public class ApiClientIntegrationTest {
         return apiClient.createFolder(parentFolderId, randomFolderName).execute();
     }
 
+    private RemoteFolder createRemoteFolder(String path) throws IOException, ApiError {
+        String randomFolderName = UUID.randomUUID().toString();
+        return apiClient.createFolder(path + randomFolderName).execute();
+    }
+
     private RemoteFile createRemoteFile() throws IOException, ApiError {
         String someName = UUID.randomUUID().toString();
         byte[] fileContents = someName.getBytes();
         return apiClient.createFile(RemoteFolder.ROOT_FOLDER_ID, someName + ".txt", DataSource.create(fileContents)).execute();
+    }
+
+    private RemoteFile createRemoteFile(String path) throws IOException, ApiError {
+        String someName = UUID.randomUUID().toString();
+        byte[] fileContents = someName.getBytes();
+        return apiClient.createFile(path, someName + ".txt", DataSource.create(fileContents)).execute();
     }
 
     private boolean entryExistsInRoot(RemoteEntry entry) throws IOException, ApiError {

--- a/java-core/src/test/java/com/pcloud/sdk/ApiClientIntegrationTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiClientIntegrationTest.java
@@ -54,6 +54,13 @@ public class ApiClientIntegrationTest {
     }
 
     @Test
+    public void testGetFolder() throws Exception {
+        long id = RemoteFolder.ROOT_FOLDER_ID;
+        RemoteFolder folder = apiClient.listFolder(id, true).execute();
+        assertEquals(id, folder.folderId());
+    }
+
+    @Test
     public void testListFolderByPath() throws Exception {
         apiClient.listFolder("/").execute();
     }

--- a/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
@@ -84,13 +84,13 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void createFolder_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.createFolder((RemoteFolder) null, null);
+        instance.createFolder(null, null);
     }
 
     @Test
     public void createFolder_ThrowsOnNullStringArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.createFolder((String) null, null);
+        instance.createFolder(null);
     }
 
     @Test

--- a/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
@@ -141,7 +141,7 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void moveFolder_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.moveFolder(null, null);
+        instance.moveFolder((RemoteFolder) null, (RemoteFolder) null);
     }
 
     @Test

--- a/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
@@ -154,12 +154,31 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     public void moveFolder_ReturnsANonNullCall() throws Exception {
         assertNotNull(instance.moveFolder(1, 2));
         assertNotNull(instance.moveFolder(new DummyFolder("1", 1), new DummyFolder("2", 2)));
+        assertNotNull(instance.moveFolder("/Some Folder", "/Some Other Folder/"));
     }
 
     @Test
     public void moveFolder_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.moveFolder((RemoteFolder) null, (RemoteFolder) null);
+        instance.moveFolder(null, new DummyFolder("1", 1));
+    }
+
+    @Test
+    public void moveFolder_ThrowsOnNullRemoteFolderArgument2() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.moveFolder(new DummyFolder("1", 1), null);
+    }
+
+    @Test
+    public void moveFolder_ThrowsOnNullPathArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.moveFolder((String) null, "/Some Folder/");
+    }
+
+    @Test
+    public void moveFolder_ThrowsOnNullToPathArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.moveFolder("/Some Folder", (String) null);
     }
 
     @Test
@@ -333,6 +352,18 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     public void moveFile_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
         instance.moveFile(new DummyFile(1, "somename"), null);
+    }
+
+    @Test
+    public void moveFile_ThrowsOnNullPathArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.moveFile(null, "/");
+    }
+
+    @Test
+    public void moveFile_ThrowsOnNullToPathArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.moveFile("/somefile.txt", null);
     }
 
     @Test

--- a/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
+++ b/java-core/src/test/java/com/pcloud/sdk/ApiServiceTest.java
@@ -84,7 +84,13 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void createFolder_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.createFolder(null, null);
+        instance.createFolder((RemoteFolder) null, null);
+    }
+
+    @Test
+    public void createFolder_ThrowsOnNullStringArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.createFolder((String) null, null);
     }
 
     @Test
@@ -99,13 +105,25 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void deleteFolder_ThrowsOnNullRemoteFolderArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.deleteFolder(null);
+        instance.deleteFolder((RemoteFolder) null);
     }
 
     @Test
     public void deleteFolder_ThrowsOnNullRemoteFolderArgument2() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.deleteFolder(null, false);
+        instance.deleteFolder((RemoteFolder) null, false);
+    }
+
+    @Test
+    public void deleteFolder_ThrowsOnNullStringArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.deleteFolder((String) null);
+    }
+
+    @Test
+    public void deleteFolder_ThrowsOnNullStringArgument2() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.deleteFolder((String) null, false);
     }
 
     @Test
@@ -205,7 +223,13 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void deleteFile_ThrowsOnNullRemoteFileArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.deleteFile(null);
+        instance.deleteFile((RemoteFile) null);
+    }
+
+    @Test
+    public void deleteFile_ThrowsOnNullStringArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.deleteFile((String) null);
     }
 
     @Test
@@ -217,7 +241,13 @@ public abstract class ApiServiceTest<T extends ApiClient> {
     @Test
     public void getDownloadLink_ThrowsOnNullRemoteFileArgument() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        instance.createFileLink(null, DownloadOptions.DEFAULT);
+        instance.createFileLink((RemoteFile) null, DownloadOptions.DEFAULT);
+    }
+
+    @Test
+    public void getDownloadLink_ThrowsOnNullStringArgument() throws Exception {
+        exceptionRule.expect(IllegalArgumentException.class);
+        instance.createFileLink((String) null, DownloadOptions.DEFAULT);
     }
 
     @Test

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -95,6 +95,11 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFolder> createFolder(String path, String folderName) {
+        return null;
+    }
+
+    @Override
     public Call<Boolean> deleteFolder(long folderId) {
         return null;
     }
@@ -111,6 +116,16 @@ public class DummyDownloadingApiClient implements ApiClient {
 
     @Override
     public Call<Boolean> deleteFolder(RemoteFolder folder, boolean recursively) {
+        return null;
+    }
+
+    @Override
+    public Call<Boolean> deleteFolder(String path) {
+        return null;
+    }
+
+    @Override
+    public Call<Boolean> deleteFolder(String path, boolean recursively) {
         return null;
     }
 
@@ -200,6 +215,26 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data, UploadOptions uploadOptions) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data, Date modifiedDate, ProgressListener listener) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> createFile(String path, String filename, DataSource data, Date modifiedDate, ProgressListener listener, UploadOptions uploadOptions) {
+        return null;
+    }
+
+    @Override
     public Call<Boolean> deleteFile(RemoteFile file) {
         return null;
     }
@@ -210,12 +245,22 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<Boolean> deleteFile(String path) {
+        return null;
+    }
+
+    @Override
     public Call<FileLink> createFileLink(RemoteFile file, DownloadOptions options) {
         return new DummyCall<FileLink>(new DummyDownloadLink());
     }
 
     @Override
     public Call<FileLink> createFileLink(long fileid, DownloadOptions options) {
+        return new DummyCall<FileLink>(new DummyDownloadLink());
+    }
+
+    @Override
+    public Call<FileLink> createFileLink(String path, DownloadOptions options) {
         return new DummyCall<FileLink>(new DummyDownloadLink());
     }
 

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -95,7 +95,7 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
-    public Call<RemoteFolder> createFolder(String path, String folderName) {
+    public Call<RemoteFolder> createFolder(String path) {
         return null;
     }
 

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -135,6 +135,11 @@ public class DummyDownloadingApiClient implements ApiClient {
     }
 
     @Override
+    public Call<RemoteFolder> moveFolder(String path, String toPath) {
+        return null;
+    }
+
+    @Override
     public Call<RemoteFolder> copyFolder(long folderId, long toFolderId) {
         return null;
     }
@@ -331,6 +336,11 @@ public class DummyDownloadingApiClient implements ApiClient {
 
     @Override
     public Call<RemoteFile> moveFile(RemoteFile file, RemoteFolder toFolder) {
+        return null;
+    }
+
+    @Override
+    public Call<RemoteFile> moveFile(String path, String toPath) {
         return null;
     }
 


### PR DESCRIPTION
- `moveFile()`: allow to move files using paths instead of IDs
- `moveFolder()`: allow to move folders using paths instead of IDs
 - `createFolder()`: allow to create folders using paths instead of IDs
- `deleteFolder()`: allow to delete folders using paths instead of IDs
- `createFile()`: allow to create files using paths instead of IDs
- `deleteFile()`: allow to delete files using paths instead of IDs
- `createFileLink()`: allow to create file links using paths instead of IDs
