### PR TITLE
Proposal to add checksumfile API as requested in #25

### DIFF
--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -1050,9 +1050,9 @@ public interface ApiClient {
     /**
      * Calculate checksums for the file with the provided {@code fileId}.
      * <p>
-     * 'sha1' checksum is returned from both US and Europe API servers. 
-     * 'md5' is returned only from US API servers, not added in Europe as it's quite old and has collions. 
-     * 'sha256' is returned in Europe only.
+     * 'SHA-1' checksum is returned from both US and Europe API servers. 
+     * 'MD-5' is returned only from US API servers, not added in Europe as it's quite old and has collions. 
+     * 'SHA-256' is returned in Europe only.
      * <p>
      * For more information, see the related <a href="https://docs.pcloud.com/methods/file/checksumfile.html" target="_blank">documentation page</a>.
      * 
@@ -1064,9 +1064,9 @@ public interface ApiClient {
     /**
      * Calculate checksums for the file with the provided {@code path}.
      * <p>    
-     * 'sha1' checksum is returned from both US and Europe API servers. 
-     * 'md5' is returned only from US API servers, not added in Europe as it's quite old and has collions. 
-     * 'sha256' is returned in Europe only.
+     * 'SHA-1' checksum is returned from both US and Europe API servers. 
+     * 'MD-5' is returned only from US API servers, not added in Europe as it's quite old and has collions. 
+     * 'SHA-256' is returned in Europe only.
      * <p>
      * For more information, see the related <a href="https://docs.pcloud.com/methods/file/checksumfile.html" target="_blank">documentation page</a>.
      * 

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -1070,7 +1070,7 @@ public interface ApiClient {
      * <p>
      * For more information, see the related <a href="https://docs.pcloud.com/methods/file/checksumfile.html" target="_blank">documentation page</a>.
      * 
-     * @param fileId target file id.
+     * @param path target file path.
      * @return {@link Call} resulting in a Map instance holding all available hashes for the requested path.
      * @throws IllegalArgumentException on a null or empty {@code path} argument.
      */

--- a/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/ApiClient.java
@@ -18,6 +18,7 @@
 package com.pcloud.sdk;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -1045,6 +1046,35 @@ public interface ApiClient {
      * @throws IllegalArgumentException on a null or empty {@code path} argument.
      */
     Call<RemoteFile> loadFile(String path);
+
+    /**
+     * Calculate checksums for the file with the provided {@code fileId}.
+     * <p>
+     * 'sha1' checksum is returned from both US and Europe API servers. 
+     * 'md5' is returned only from US API servers, not added in Europe as it's quite old and has collions. 
+     * 'sha256' is returned in Europe only.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/checksumfile.html" target="_blank">documentation page</a>.
+     * 
+     * @param fileId target file id.
+     * @return {@link Call} resulting in a Map instance holding all available hashes for the requested file id.
+     */
+    Call<Map<String, String>> checksumFile(long fileId);
+
+    /**
+     * Calculate checksums for the file with the provided {@code path}.
+     * <p>    
+     * 'sha1' checksum is returned from both US and Europe API servers. 
+     * 'md5' is returned only from US API servers, not added in Europe as it's quite old and has collions. 
+     * 'sha256' is returned in Europe only.
+     * <p>
+     * For more information, see the related <a href="https://docs.pcloud.com/methods/file/checksumfile.html" target="_blank">documentation page</a>.
+     * 
+     * @param fileId target file id.
+     * @return {@link Call} resulting in a Map instance holding all available hashes for the requested path.
+     * @throws IllegalArgumentException on a null or empty {@code path} argument.
+     */
+    Call<Map<String, String>> checksumFile(String path);
 
     /**
      * Load a specific folder.

--- a/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/RealApiClient.java
@@ -36,6 +36,7 @@ import com.pcloud.sdk.UploadOptions;
 import com.pcloud.sdk.UserInfo;
 import com.pcloud.sdk.internal.networking.APIHttpException;
 import com.pcloud.sdk.internal.networking.ApiResponse;
+import com.pcloud.sdk.internal.networking.GetChecksumFileResponse;
 import com.pcloud.sdk.internal.networking.GetFileResponse;
 import com.pcloud.sdk.internal.networking.GetFolderResponse;
 import com.pcloud.sdk.internal.networking.GetLinkResponse;
@@ -745,6 +746,45 @@ class RealApiClient implements ApiClient {
             }
         });
     }
+
+    @Override
+    public Call<Map<String, String>> checksumFile(long fileId) {
+        HttpUrl.Builder urlBuilder = apiHost.newBuilder()
+                .addPathSegment("checksumfile")
+                .addQueryParameter("fileid", String.valueOf(fileId));
+
+        Request request = newRequest()
+                .url(urlBuilder.build())
+                .get()
+                .build();
+
+        return newCall(request, new ResponseAdapter<Map<String, String>>() {
+            @Override
+            public Map<String, String> adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetChecksumFileResponse.class).getChecksums();
+            }
+        });
+    }
+
+    @Override
+    public Call<Map<String, String>> checksumFile(String path) {
+        HttpUrl.Builder urlBuilder = apiHost.newBuilder()
+                .addPathSegment("checksumfile")
+                .addEncodedQueryParameter("path", String.valueOf(path));
+
+        Request request = newRequest()
+                .url(urlBuilder.build())
+                .get()
+                .build();
+
+        return newCall(request, new ResponseAdapter<Map<String, String>>() {
+            @Override
+            public Map<String, String> adapt(Response response) throws IOException, ApiError {
+                return getAsApiResponse(response, GetChecksumFileResponse.class).getChecksums();
+            }
+        });
+    }
+
 
     @Override
     public Call<RemoteFolder> loadFolder(long folderId) {

--- a/java-core/src/main/java/com/pcloud/sdk/internal/networking/GetChecksumFileResponse.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/networking/GetChecksumFileResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 pCloud AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pcloud.sdk.internal.networking;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.annotations.Expose;
+
+public class GetChecksumFileResponse extends ApiResponse {
+
+    @Expose
+    public String sha1 = null;
+    @Expose
+    public String md5 = null;
+    @Expose
+    public String sha256 = null;
+    
+    /* possibility to also return file metadata not used
+    @Expose
+    @SerializedName("metadata")
+    private RemoteFile remoteFile;
+
+    
+    public RemoteFile getFile() {
+        return remoteFile;
+    }
+    */
+    
+    public Map<String, String> getChecksums() {
+    	Map<String, String> result = new HashMap<>();
+    	if (sha1!=null) {
+    		result.put("sha1", sha1);
+    	}
+    	if (md5!=null) {
+    		result.put("md5", md5);
+    	}
+    	if (sha256!=null) {
+    		result.put("sha256", sha256);
+    	}
+    	return result;
+    }
+}

--- a/java-core/src/main/java/com/pcloud/sdk/internal/networking/GetChecksumFileResponse.java
+++ b/java-core/src/main/java/com/pcloud/sdk/internal/networking/GetChecksumFileResponse.java
@@ -30,27 +30,30 @@ public class GetChecksumFileResponse extends ApiResponse {
     @Expose
     public String sha256 = null;
     
-    /* possibility to also return file metadata not used
-    @Expose
-    @SerializedName("metadata")
-    private RemoteFile remoteFile;
-
+//    // possibility to also return file metadata not used 
+//    @Expose
+//    @SerializedName("metadata")
+//    private RemoteFile remoteFile;
+//
+//    
+//    public RemoteFile getFile() {
+//        return remoteFile;
+//    }
     
-    public RemoteFile getFile() {
-        return remoteFile;
-    }
-    */
-    
+    /**
+     * 
+     * @return list of hashes available. possible keys are "SHA-1" (exists always), "MD-5" (us only), "SHA-256" (eu only).
+     */
     public Map<String, String> getChecksums() {
     	Map<String, String> result = new HashMap<>();
     	if (sha1!=null) {
-    		result.put("sha1", sha1);
+    		result.put("SHA-1", sha1);
     	}
     	if (md5!=null) {
-    		result.put("md5", md5);
+    		result.put("MD-5", md5);
     	}
     	if (sha256!=null) {
-    		result.put("sha256", sha256);
+    		result.put("SHA-256", sha256);
     	}
     	return result;
     }

--- a/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
+++ b/java-core/src/test/java/com/pcloud/sdk/utils/DummyDownloadingApiClient.java
@@ -36,6 +36,7 @@ import com.pcloud.sdk.UserInfo;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import okhttp3.Cache;
@@ -364,6 +365,16 @@ public class DummyDownloadingApiClient implements ApiClient {
         return null;
     }
 
+	@Override
+	public Call<Map<String, String>> checksumFile(long fileId) {
+		return null;
+	}
+
+	@Override
+	public Call<Map<String, String>> checksumFile(String path) {
+		return null;
+	}
+
     @Override
     public Call<RemoteFolder> loadFolder(long folderId) {
         return null;
@@ -533,4 +544,5 @@ public class DummyDownloadingApiClient implements ApiClient {
             return null;
         }
     }
+
 }


### PR DESCRIPTION
This is a proposal for issue #25 

The missing checksum query functionality is added to java-core.
The "stat" method is very similair to "checksumfile". So, I copied the code from "loadFile()" for the new methods "checksumFile()".

Of course there are other possibilities for the return value. But I was unsure, where to add this return POJO.
So, I used a Map which returns the hash-type as key and the hashvalue as value.
Unfilled hashes are not returned in the map.